### PR TITLE
Fix wrong data type for sample_rate for older esp-idf versions

### DIFF
--- a/src/audio/sinks/esp/SPDIFAudioSink.cpp
+++ b/src/audio/sinks/esp/SPDIFAudioSink.cpp
@@ -85,7 +85,11 @@ bool SPDIFAudioSink::setParams(uint32_t sampleRate, uint8_t channelCount, uint8_
 
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-    	.sample_rate = (uint32_t)sample_rate,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+    	.sample_rate = (uint32_t) sample_rate,
+#else
+        .sample_rate = (int) sample_rate,
+#endif
         .bits_per_sample = (i2s_bits_per_sample_t)(bitDepth * 2),
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = I2S_COMM_FORMAT_STAND_I2S,


### PR DESCRIPTION
Prior to esp-idf version 4.4, the data type of `i2s_config_t::sample_rate` was not `uint32_t` but `int`. This leads to a compiler error when using an older toolchain for e.g. `cspot`:

```
cspot/cspot/bell/src/sinks/esp/SPDIFAudioSink.cpp:86:21: error: narrowing conversion of '(uint32_t)sample_rate' from 'uint32_t' {aka 'unsigned int'} to 'int' inside { } [-Werror=narrowing]
      .sample_rate = (uint32_t) sample_rate,
                     ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors

$ idf.py --version
ESP-IDF v4.3.2
```
See definition of `i2s_config_t` in [v4.3.3](https://github.com/espressif/esp-idf/blob/v4.3.3/components/hal/include/hal/i2s_types.h#L125) and in [v4.4](https://github.com/espressif/esp-idf/blob/v4.4/components/hal/include/hal/i2s_hal.h#L44)
