### PR TITLE
Disable padding for AES-ECB in OpenSSL backend

### DIFF
--- a/src/CryptoOpenSSL.cpp
+++ b/src/CryptoOpenSSL.cpp
@@ -127,6 +127,7 @@ void CryptoOpenSSL::aesECBdecrypt(const std::vector<uint8_t>& key, std::vector<u
     int len = 0;
 
     EVP_DecryptInit_ex(ctx, EVP_aes_192_ecb(), NULL, key.data(), NULL);
+    EVP_CIPHER_CTX_set_padding(ctx, 0); // disable padding
     EVP_DecryptUpdate(ctx, data.data(), &len, data.data(), data.size());
     EVP_DecryptFinal_ex(ctx, data.data() + len, &len);
 


### PR DESCRIPTION
Change padding scheme from `AES/ECB/PKCS5Padding` to `AES/ECB/NoPadding` to fix the bug https://github.com/feelfreelinux/cspot/issues/127 

I suspect that the padding issue will not affect every account (maybe depending on the length of the username), but for me this fix was necessary. Please make sure that this fix does not break authentication for other accounts that did not experience https://github.com/feelfreelinux/cspot/issues/127  in the first place.

See also https://github.com/feelfreelinux/cspot/issues/127#issuecomment-1200154714 for more explanation