### PR TITLE
bring back BELL_EXTERNAL_TREMOR + allow HTTP serverPort to be automatic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(AUDIO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/audio")
 add_definitions("-DUSE_DEFAULT_STDLIB=1")
 
 # Main library sources
-file(GLOB SOURCES "src/*.cpp" "src/*.c" "nanopb/*.c" "src/audio/container/*.cpp")
+file(GLOB SOURCES "src/*.cpp" "src/*.c" "nanopb/*.c")
 list(APPEND EXTRA_INCLUDES "include/platform")
 list(APPEND EXTRA_INCLUDES "include/audio/container")
 
@@ -133,6 +133,8 @@ else()
 endif()
 
 if(NOT BELL_DISABLE_CODECS)
+    file(GLOB EXTRA_SOURCES "src/audio/container/*.cpp")
+    list(APPEND SOURCES "${EXTRA_SOURCES}")
     list(APPEND SOURCES "${AUDIO_DIR}/codec/DecoderGlobals.cpp")
     list(APPEND SOURCES "${AUDIO_DIR}/codec/BaseCodec.cpp")
     list(APPEND SOURCES "${AUDIO_DIR}/codec/AudioCodecs.cpp")
@@ -195,6 +197,8 @@ if(NOT BELL_DISABLE_CODECS)
     # Enable global codecs
     string(REPLACE ";" " " CODEC_FLAGS "${CODEC_FLAGS}")
     set_source_files_properties("${AUDIO_DIR}/codec/AudioCodecs.cpp" PROPERTIES COMPILE_FLAGS "${CODEC_FLAGS}")
+elseif(BELL_EXTERNAL_TREMOR) 	
+    list(APPEND EXTRA_LIBS ${BELL_EXTERNAL_TREMOR})
 endif()
 
 if(NOT BELL_DISABLE_SINKS)

--- a/include/HTTPServer.h
+++ b/include/HTTPServer.h
@@ -63,14 +63,14 @@ namespace bell
         std::string urlDecode(std::string str);
 
     public:
-        HTTPServer(int serverPort);
+        HTTPServer(int serverPort = 0);
 
         void registerHandler(RequestType requestType, const std::string &, httpHandler, bool readDataToStr = false);
         void respond(const HTTPResponse &);
         void redirectTo(const std::string&, int connectionFd);
         void publishEvent(std::string eventName, std::string eventData);
         void closeConnection(int connection);
-        void listen();
+        void listen(std::function<void()> const& callback = nullptr);
     };
 }
 #endif

--- a/include/HTTPServer.h
+++ b/include/HTTPServer.h
@@ -63,14 +63,14 @@ namespace bell
         std::string urlDecode(std::string str);
 
     public:
-        HTTPServer(int serverPort);
+        HTTPServer(int serverPort = 0);
 
         void registerHandler(RequestType requestType, const std::string &, httpHandler, bool readDataToStr = false);
         void respond(const HTTPResponse &);
         void redirectTo(const std::string&, int connectionFd);
         void publishEvent(std::string eventName, std::string eventData);
         void closeConnection(int connection);
-        void listen();
+        void listen(std::function<void()> const& gotPort = NULL);
     };
 }
 #endif

--- a/src/HTTPServer.cpp
+++ b/src/HTTPServer.cpp
@@ -105,7 +105,9 @@ void bell::HTTPServer::listen(std::function<void()> const& callback) {
                                  std::string(strerror(errno)));
     }
 
-    if (callback) callback();
+    if (callback) {
+        callback();
+    }
 
     FD_ZERO(&activeFdSet);
     FD_SET(sockfd, &activeFdSet);

--- a/src/HTTPServer.cpp
+++ b/src/HTTPServer.cpp
@@ -65,7 +65,7 @@ void bell::HTTPServer::registerHandler(RequestType requestType,
                                                .readBodyToStr = readBodyToStr});
 }
 
-void bell::HTTPServer::listen() {
+void bell::HTTPServer::listen(std::function<void()> const& gotPort) {
     BELL_LOG(info, "http", "Starting server at port %d", this->serverPort);
 
     // setup address
@@ -89,6 +89,15 @@ void bell::HTTPServer::listen() {
         throw std::runtime_error("bind failed on port " +
                                  std::to_string(this->serverPort) + ": " +
                                  std::string(strerror(errno)));
+    }
+    if (!this->serverPort) {
+        struct sockaddr_in addr;
+        socklen_t len = sizeof(struct sockaddr);
+
+        getsockname(sockfd, (struct sockaddr*) &addr, &len);
+        this->serverPort = ntohs(addr.sin_port);
+        BELL_LOG(info, "http", "Bound to port %u", this->serverPort);
+        if (gotPort) gotPort();
     }
     if (::listen(sockfd, 5) < 0) {
         throw std::runtime_error("listen failed on port " +

--- a/src/HTTPServer.cpp
+++ b/src/HTTPServer.cpp
@@ -65,7 +65,7 @@ void bell::HTTPServer::registerHandler(RequestType requestType,
                                                .readBodyToStr = readBodyToStr});
 }
 
-void bell::HTTPServer::listen() {
+void bell::HTTPServer::listen(std::function<void()> const& callback) {
     BELL_LOG(info, "http", "Starting server at port %d", this->serverPort);
 
     // setup address
@@ -90,11 +90,22 @@ void bell::HTTPServer::listen() {
                                  std::to_string(this->serverPort) + ": " +
                                  std::string(strerror(errno)));
     }
+    if (!this->serverPort) {
+        struct sockaddr_in addr;
+        socklen_t len = sizeof(struct sockaddr);
+
+        getsockname(sockfd, (struct sockaddr*) &addr, &len);
+        this->serverPort = ntohs(addr.sin_port);
+        BELL_LOG(info, "http", "Bound to port %u", this->serverPort);
+    }
+
     if (::listen(sockfd, 5) < 0) {
         throw std::runtime_error("listen failed on port " +
                                  std::to_string(this->serverPort) + ": " +
                                  std::string(strerror(errno)));
     }
+
+    if (callback) callback();
 
     FD_ZERO(&activeFdSet);
     FD_SET(sockfd, &activeFdSet);


### PR DESCRIPTION
In previous PR I forgot the need to have EXTERNAL_TREMOR. This is needed when the application incorporating bell has its own tremor version, so we still want at least this codec and need to provide it to Bell.

The other part of the PR is as I'm writing the CSpot / UPnP bridge, I need Bell and CSpot to be able to be fully multi-instantiated. But so far, when there is no existing blob, Bell wants a HTTP server on a port set at creating of the HTTPServer object and this port is needed in the ZeroConf broadcast. But here I need multiple instances of HTTPServer/ZeroConf (one per UPnP device), so manually forcing the port is very inconvenient.

We can now give no port (=0) to the HTTPServer and it will set it with an optional callback when it binds to a socket (at listen()). The callback is very minimum as I'd assume (see PR on cspot) that all it needs to do is fire the ZeroConf broacast and so it can capture what required before.