### PR TITLE
Allow HTTPServer::listen to be interrupted

### DIFF
--- a/include/HTTPServer.h
+++ b/include/HTTPServer.h
@@ -44,6 +44,7 @@ namespace bell
         fd_set readFds;
         fd_set activeFdSet, readFdSet;
 
+        bool listening = false;
         bool isClosed = true;
         bool writingResponse = false;
 
@@ -71,6 +72,7 @@ namespace bell
         void publishEvent(std::string eventName, std::string eventData);
         void closeConnection(int connection);
         void listen(std::function<void()> const& callback = nullptr);
+        void stopListen(void) { listening = false;  };
     };
 }
 #endif

--- a/src/HTTPServer.cpp
+++ b/src/HTTPServer.cpp
@@ -109,10 +109,11 @@ void bell::HTTPServer::listen(std::function<void()> const& callback) {
         callback();
     }
 
+    listening = true;
     FD_ZERO(&activeFdSet);
     FD_SET(sockfd, &activeFdSet);
 
-    for (int maxfd = sockfd;;) {
+    for (int maxfd = sockfd; listening;) {
         /* Block until input arrives on one or more active sockets. */
         readFdSet = activeFdSet;
         struct timeval tv = {0, 100000};
@@ -164,6 +165,13 @@ void bell::HTTPServer::listen(std::function<void()> const& callback) {
         }
 
     }
+
+    // close and erase all connections
+    for (auto it = this->connections.cbegin(); it != this->connections.cend(); ++it) {
+        close((*it).first);
+    }
+    connections.clear();
+    close(sockfd);
 }
 
 void bell::HTTPServer::readFromClient(int clientFd) {


### PR DESCRIPTION
This is necessary for an application that wants to exit from listen() loop