### PR TITLE
Make MQTT compile under Win32 + allow base64 to work w/o object

### DIFF
--- a/external/mqtt/include/mqtt_pal.h
+++ b/external/mqtt/include/mqtt_pal.h
@@ -29,7 +29,6 @@ SOFTWARE.
 extern "C" {
 #endif
 #include <sys/types.h>
-#include <sys/socket.h>
 // #ifdef ESP_PLATFORM
 // #define MQTT_USE_MBEDTLS
 // #else
@@ -83,6 +82,7 @@ extern "C" {
     #include <time.h>
     #include <arpa/inet.h>
     #include <pthread.h>
+    #include <sys/socket.h>
 
     #define MQTT_PAL_HTONS(s) htons(s)
     #define MQTT_PAL_NTOHS(s) ntohs(s)

--- a/external/opencore-aacdec/CMakeLists.txt
+++ b/external/opencore-aacdec/CMakeLists.txt
@@ -1,7 +1,9 @@
 file(GLOB AACDEC_SOURCES "src/*.c")
 file(GLOB AACDEC_HEADERS "src/*.h" "oscl/*.h" "include/*.h")
 
-add_library(opencore-aacdec SHARED ${AACDEC_SOURCES})
+add_library(opencore-aacdec STATIC ${AACDEC_SOURCES})
+if(NOT MSVC)
+	target_compile_options(opencore-aacdec PRIVATE -Wno-array-parameter)
+endif()	
 add_definitions(-DAAC_PLUS -DHQ_SBR -DPARAMETRICSTEREO -DC_EQUIVALENT)
-target_compile_options(opencore-aacdec PRIVATE -Wno-array-parameter)
 target_include_directories(opencore-aacdec PUBLIC "src/" "oscl/" "include/")

--- a/main/io/BellMQTTClient.cpp
+++ b/main/io/BellMQTTClient.cpp
@@ -1,7 +1,9 @@
 #include "BellMQTTClient.h"
 
-#include <stddef.h>     // for NULL
+#ifndef _WIN32
 #include <sys/fcntl.h>  // for fcntl, F_GETFL, F_SETFL, O_NONBLOCK
+#endif
+#include <stddef.h>     // for NULL
 #include <stdexcept>    // for runtime_error
 
 #include "BellLogger.h"  // for AbstractLogger, BELL_LOG
@@ -27,8 +29,13 @@ void bell::MQTTClient::connect(const std::string& host, uint16_t port,
   }
 
   // Set the socket to non-blocking
+#ifdef _WIN32
+  u_long iMode = 1;
+  ioctlsocket(socket.getFd(), FIONBIO, &iMode);
+#else
   int status = fcntl(socket.getFd(), F_SETFL,
-                     fcntl(socket.getFd(), F_GETFL, 0) | O_NONBLOCK);
+      fcntl(socket.getFd(), F_GETFL, 0) | O_NONBLOCK);
+#endif
 
   // Pass pointer to this object to the publish callback
   client.publish_response_callback_state = this;

--- a/main/utilities/include/Crypto.h
+++ b/main/utilities/include/Crypto.h
@@ -31,8 +31,8 @@ class CryptoMbedTLS {
   CryptoMbedTLS();
   ~CryptoMbedTLS();
   // Base64
-  std::vector<uint8_t> base64Decode(const std::string& data);
-  std::string base64Encode(const std::vector<uint8_t>& data);
+  static std::vector<uint8_t> base64Decode(const std::string& data);
+  static std::string base64Encode(const std::vector<uint8_t>& data);
 
   // Sha1
   void sha1Init();


### PR DESCRIPTION
Per commit message, this fixes MQTT not compiling under Win32 and I also turned base64 function into statics so that they can run without a crypto object which is needed for my cspot PR. I also modified opencore-aacdec's CMakefile to make it work under Win32. I made library static as I assumed (maybe wrongly) that we always want static, like all other codecs.