### PR TITLE
clean MDNS at exit

### DIFF
--- a/external/civetweb/civetweb.c
+++ b/external/civetweb/civetweb.c
@@ -22482,9 +22482,13 @@ mg_init_library(unsigned features)
 			file_mutex_init =
 			    pthread_mutex_init(&global_log_file_lock, &pthread_mutex_attr);
 			if (file_mutex_init == 0) {
+#ifdef WINSOCK_START
 				/* Start WinSock */
 				WSADATA data;
 				failed = wsa = WSAStartup(MAKEWORD(2, 2), &data);
+#else
+				failed = wsa = 0;
+#endif
 			}
 #else
 			mutexattr_init = pthread_mutexattr_init(&pthread_mutex_attr);
@@ -22498,7 +22502,9 @@ mg_init_library(unsigned features)
 		if (failed) {
 #if defined(_WIN32)
 			if (wsa == 0) {
+#ifdef WINSOCK_START
 				(void)WSACleanup();
+#endif
 			}
 			if (file_mutex_init == 0) {
 				(void)pthread_mutex_destroy(&global_log_file_lock);
@@ -22598,7 +22604,9 @@ mg_exit_library(void)
 #endif
 
 #if defined(_WIN32)
+#ifdef WINSOCK_START
 		(void)WSACleanup();
+#endif
 		(void)pthread_mutex_destroy(&global_log_file_lock);
 #else
 		(void)pthread_mutexattr_destroy(&pthread_mutex_attr);

--- a/main/io/include/BellHTTPServer.h
+++ b/main/io/include/BellHTTPServer.h
@@ -19,6 +19,7 @@ namespace bell {
 class BellHTTPServer : public CivetHandler {
  public:
   BellHTTPServer(int serverPort);
+  ~BellHTTPServer();
 
   enum class WSState { CONNECTED, READY, CLOSED };
 
@@ -99,6 +100,8 @@ class BellHTTPServer : public CivetHandler {
   Router postRequestsRouter;
   std::mutex responseMutex;
   HTTPHandler notFoundHandler;
+
+  static std::mutex initMutex;
 
   bool handleGet(CivetServer* server, struct mg_connection* conn);
   bool handlePost(CivetServer* server, struct mg_connection* conn);

--- a/main/platform/linux/MDNSService.cpp
+++ b/main/platform/linux/MDNSService.cpp
@@ -46,6 +46,7 @@ class implMDNSService : public MDNSService {
 #ifndef BELL_DISABLE_AVAHI
   implMDNSService(AvahiEntryGroup* avahiGroup) : avahiGroup(avahiGroup){};
 #endif
+  virtual ~implMDNSService();
   void unregisterService();
 };
 
@@ -195,4 +196,15 @@ std::unique_ptr<MDNSService> MDNSService::registerService(
   BELL_LOG(error, "MDNS", "cannot start any mDNS listener for %s",
            serviceName.c_str());
   return NULL;
+}
+
+implMDNSService::~implMDNSService() {
+#ifndef BELL_DISABLE_AVAHI
+ if (implMDNSService::avahiClient) {
+    avahi_client_free(implMDNSService::avahiClient);
+ } else     
+#endif       
+ if (implMDNSService::mdnsServer) {
+    mdnsd_stop(implMDNSService::mdnsServer);
+  }
 }

--- a/main/platform/linux/MDNSService.cpp
+++ b/main/platform/linux/MDNSService.cpp
@@ -48,7 +48,6 @@ class implMDNSService : public MDNSService {
 #ifndef BELL_DISABLE_AVAHI
   implMDNSService(AvahiEntryGroup* avahiGroup) : avahiGroup(avahiGroup){};
 #endif
-  virtual ~implMDNSService();
   void unregisterService();
 };
 
@@ -70,11 +69,21 @@ void implMDNSService::unregisterService() {
 #ifndef BELL_DISABLE_AVAHI
   if (avahiGroup) {
     avahi_entry_group_free(avahiGroup);
+    if (!--instances && implMDNSService::avahiClient) {
+      avahi_client_free(implMDNSService::avahiClient);
+      avahi_simple_poll_free(implMDNSService::avahiPoll);
+      implMDNSService::avahiClient = nullptr;
+      implMDNSService::avahiPoll = nullptr;
+    }
   } else
 #endif
   {
     mdns_service_remove(implMDNSService::mdnsServer, service);
-  }
+    if (!--instances && implMDNSService::mdnsServer) {
+     mdnsd_stop(implMDNSService::mdnsServer);
+     implMDNSService::mdnsServer = nullptr;
+    }
+  }  
 }
 
 std::unique_ptr<MDNSService> MDNSService::registerService(
@@ -199,20 +208,4 @@ std::unique_ptr<MDNSService> MDNSService::registerService(
   BELL_LOG(error, "MDNS", "cannot start any mDNS listener for %s",
            serviceName.c_str());
   return NULL;
-}
-
-implMDNSService::~implMDNSService() {
-  if (--instances) return;
-#ifndef BELL_DISABLE_AVAHI
- if (implMDNSService::avahiClient) {
-    avahi_client_free(implMDNSService::avahiClient);
-    avahi_simple_poll_free(implMDNSService::avahiPoll);
-    implMDNSService::avahiClient = nullptr;
-    implMDNSService::avahiPoll = nullptr;
- } else     
-#endif       
- if (implMDNSService::mdnsServer) {
-     mdnsd_stop(implMDNSService::mdnsServer);
-     implMDNSService::mdnsServer = nullptr;
-  }
 }

--- a/main/platform/linux/MDNSService.cpp
+++ b/main/platform/linux/MDNSService.cpp
@@ -193,19 +193,14 @@ std::unique_ptr<MDNSService> MDNSService::registerService(
     std::string type(serviceType + "." + serviceProto + ".local");
 
     BELL_LOG(info, "MDNS", "using built-in mDNS for %s", serviceName.c_str());
-    struct mdns_service* mdnsService =
+    auto service =
         mdnsd_register_svc(implMDNSService::mdnsServer, serviceName.c_str(),
-                           type.c_str(), servicePort, NULL, txt.data());
-    if (mdnsService) {
-      auto service =
-          mdnsd_register_svc(implMDNSService::mdnsServer, serviceName.c_str(),
                              type.c_str(), servicePort, NULL, txt.data());
 
-      return std::make_unique<implMDNSService>(service);
-    }
+    if (service) return std::make_unique<implMDNSService>(service);
   }
 
   BELL_LOG(error, "MDNS", "cannot start any mDNS listener for %s",
            serviceName.c_str());
-  return NULL;
+  return nullptr;
 }

--- a/main/platform/linux/MDNSService.cpp
+++ b/main/platform/linux/MDNSService.cpp
@@ -206,7 +206,9 @@ implMDNSService::~implMDNSService() {
 #ifndef BELL_DISABLE_AVAHI
  if (implMDNSService::avahiClient) {
     avahi_client_free(implMDNSService::avahiClient);
+    avahi_simple_poll_free(implMDNSService::avahiPoll);
     implMDNSService::avahiClient = nullptr;
+    implMDNSService::avahiPoll = nullptr;
  } else     
 #endif       
  if (implMDNSService::mdnsServer) {

--- a/main/platform/win32/MDNSService.cpp
+++ b/main/platform/win32/MDNSService.cpp
@@ -26,6 +26,7 @@ class implMDNSService : public MDNSService {
  public:
   static struct mdnsd* mdnsServer;
   implMDNSService(struct mdns_service* service) : service(service){};
+  virtual ~implMDNSService();
 };
 
 /**
@@ -95,4 +96,10 @@ std::unique_ptr<MDNSService> MDNSService::registerService(
                          type.c_str(), servicePort, NULL, txt.data());
 
   return std::make_unique<implMDNSService>(service);
+}
+
+implMDNSService::~implMDNSService() {
+  if (implMDNSService::mdnsServer) {
+    mdnsd_stop(implMDNSService::mdnsServer);
+  }
 }

--- a/main/platform/win32/MDNSService.cpp
+++ b/main/platform/win32/MDNSService.cpp
@@ -103,5 +103,5 @@ std::unique_ptr<MDNSService> MDNSService::registerService(
       mdnsd_register_svc(implMDNSService::mdnsServer, serviceName.c_str(),
                          type.c_str(), servicePort, NULL, txt.data());
 
-  return std::make_unique<implMDNSService>(service);
+  return service ? std::make_unique<implMDNSService>(service) : nullptr;
 }

--- a/main/utilities/include/BellTask.h
+++ b/main/utilities/include/BellTask.h
@@ -72,7 +72,11 @@ class Task {
                           (LPTHREAD_START_ROUTINE)taskEntryFunc, this, 0, NULL);
     return thread != NULL;
 #else
-    return (pthread_create(&thread, NULL, taskEntryFunc, this) == 0);
+    if (!pthread_create(&thread, NULL, taskEntryFunc, this)) {
+        pthread_detach(thread);
+        return true;
+    }
+    return false;
 #endif
   }
 
@@ -108,13 +112,7 @@ class Task {
 #endif
 
   static void* taskEntryFunc(void* This) {
-    Task* self = (Task*)This;
-    self->runTask();
-#if _WIN32
-    WaitForSingleObject(self->thread, INFINITE);
-#else
-    pthread_join(self->thread, NULL);
-#endif
+    ((Task*)This)->runTask();
     return NULL;
   }
 };


### PR DESCRIPTION
Sorry, that evolved to be a multi-issues PR

- stop mDNS server when there is no more active service
- fix memory leak due to double service creation in non-mac/win/avahi option
- belltask can't self-join, pthread must be detachhable to avoid memory leak when terminating
- submodule mdnssvc had an un-initialized option
- call mg_exit_library when destructing a BellHTTPServer but thread-protect it
